### PR TITLE
add support for Magisk 22

### DIFF
--- a/system/bin/setupFiles.sh
+++ b/system/bin/setupFiles.sh
@@ -33,6 +33,11 @@ checkMagisk() {
             busyboxPath=/data/adb/magisk
             return 1
             ;;
+        '22'[0-9a-zA-Z]*) # Version 22.x
+            hosts=/data/adb/modules/hosts/system/etc/hosts
+            busyboxPath=/data/adb/magisk
+            return 1
+            ;;
         *)
             echo -e "\n >Version: $printMagiskVersion - not supported.\n > Exiting..."
             exit


### PR DESCRIPTION
As requested by #4. There's been no change in busybox or hosts location in the version bump, so this works after just altering the compatibility check to allow v22.x.