### PR TITLE
Fixes cut error for whitelisting domains

### DIFF
--- a/system/bin/energized
+++ b/system/bin/energized
@@ -524,7 +524,7 @@ changeRedirectionIP() { sed -ie 's/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-
 # Ectract domain from URL
 # ----------------------------------------
 getDomain() {
-    domainOnly=$(echo "$1" | cut -d'/' -f3 | cut -d':' -f1 | cut -d'\@' -f2)
+    domainOnly=$(echo "$1" | cut -d'/' -f3 | cut -d':' -f1 | cut -d'@' -f2)
     case $domainOnly in
             (*[a-zA-Z]*)
             for i in $domainOnly ; do


### PR DESCRIPTION
There is no need to escape the @ sign, so I unescaped it.